### PR TITLE
Only enable ASIO for Windows in JackTrip Labs builds

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -420,6 +420,12 @@ jobs:
             CONFIG_STRING="-Drtaudio:jack=disabled -Drtaudio:default_library=static $CONFIG_STRING"
             if [[ "${{ runner.os }}" == 'Windows' ]]; then 
               CONFIG_STRING="-Drtaudio:wasapi=enabled $CONFIG_STRING"
+              # ASIO builds require Steinberg license; disable it if not CLI or signed builds from JackTrip Labs
+              if [[ "${{ matrix.nogui }}" == true ]] || [[ "${{ needs.check-secrets.outputs.should_run }}" == "true" ]]; then
+                CONFIG_STRING="-Drtaudio:asio=enabled $CONFIG_STRING"
+              else
+                CONFIG_STRING="-Drtaudio:asio=disabled $CONFIG_STRING"
+              fi
             elif [[ "${{ runner.os }}" == 'Linux' ]]; then
               CONFIG_STRING="-Drtaudio:alsa=enabled -Drtaudio:pulse=enabled -Drtaudio:werror=false $CONFIG_STRING"
             fi
@@ -432,9 +438,14 @@ jobs:
           fi
           if [[ "${{ matrix.novs }}" == true ]]; then 
             CONFIG_STRING="-Dnovs=true $CONFIG_STRING"
-          fi
-          if [[ "${{ needs.check-secrets.outputs.should_run }}" == "true" ]]; then 
-            CONFIG_STRING="-Dvsftux=true $CONFIG_STRING"
+          elif [[ "${{ needs.check-secrets.outputs.should_run }}" == "true" ]]; then
+            if [[ "${{ runner.os }}" == 'Windows' ]] || [[ "${{ runner.os }}" == 'macOS' ]]; then
+              # do not include classic mode interface in signed JackTrip Labs builds
+              CONFIG_STRING="-Dnoclassic=true $CONFIG_STRING"
+            else
+              # prefer virtual studio interface for JackTrip Labs builds on Linux
+              CONFIG_STRING="-Dvsftux=true $CONFIG_STRING"
+            fi
           fi
           if [[ "${{ matrix.weakjack }}" == true ]]; then 
             CONFIG_STRING="-Dweakjack=true $CONFIG_STRING"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,20 +1,28 @@
 # JackTrip License
 
-Copyright © 2008-2020 Juan-Pablo Caceres, Chris Chafe.
+Copyright © 2008-2024 Juan-Pablo Caceres, Chris Chafe, et al.
 SoundWIRE group at CCRMA, Stanford University.
+
+Virtual Studio interface and integration,
+Copyright © 2022-2024 JackTrip Labs, Inc.
 
 Classic mode graphical user interface originally released as QJackTrip,
 Copyright © 2020 Aaron Wyatt
 
-Virtual Studio interface and integration
-Copyright © 2022-2023 JackTrip Labs, Inc.
+The JackTrip project including Virtual Studio interface and integration
+is open source distributed under the MIT license. The Classic mode
+graphical interface is open source distributed under a GPL license.
 
-JackTrip project consists of files under MIT and GPL licenses, indicated in the
-header of individual files. Early versions of JackTrip were licensed under MIT.
+JackTrip uses the Qt library. Qt's source code can be downloaded from
+[https://download.qt.io/official_releases/qt/](https://download.qt.io/official_releases/qt/).
 
-JackTrip uses Qt library throughout the project so the resulting binaries are
-also subject to Qt's license. The builds provided on GitHub's Releases page use
-open source distribution of Qt, licensed under LGPL.
+Unsigned builds provided on GitHub's Releases page include the Classic
+mode graphical interface and use an open source distribution of Qt.
+These are distributed under a GPL license.
+
+Signed builds for Windows and Mac provided by JackTrip Labs do not
+include the Classic mode graphical interface and use a commercial
+Qt license. These are distributed under a MIT license.
 
 Windows builds of JackTrip may include support for ASIO.
 ASIO is a trademark and software of Steinberg Media Technologies GmbH.
@@ -22,6 +30,5 @@ ASIO is a trademark and software of Steinberg Media Technologies GmbH.
 Using JackTrip to join Virtual Studios on Windows computers may use AVC (h264)
 video encoders and decoders subject to the AVC Patent Portfolio License.
 
-The text of individual licenses is provided in the `LICENSES/` folder. Qt's
-source code can be downloaded from
-[https://download.qt.io/official_releases/qt/](https://download.qt.io/official_releases/qt/).
+The text of individual licenses is provided in the `LICENSES/` folder.
+

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,5 +1,8 @@
-  Copyright (c) 2020 Juan-Pablo Caceres, Chris Chafe.
+  Copyright (c) 2008-2024 Juan-Pablo Caceres, Chris Chafe, et al.
   SoundWIRE group at CCRMA, Stanford University.
+
+  Virtual Studio interface and integration
+  Copyright (c) 2022-2024 JackTrip Labs, Inc.
 
   Permission is hereby granted, free of charge, to any person
   obtaining a copy of this software and associated documentation

--- a/win/build_installer.bat
+++ b/win/build_installer.bat
@@ -55,9 +55,11 @@ if defined DYNAMIC_QT (
 	echo Including Qt%QTVERSION% Files
 	for /f "tokens=*" %%a in ('objdump -p jacktrip.exe ^| findstr Qt%QTVERSION%Qml.dll') do set VS=%%a
 	if defined VS (
-		windeployqt -release --qmldir ..\..\src\gui jacktrip.exe
+		echo Including QML files
+		windeployqt -release --qmldir ..\..\src\vs jacktrip.exe
 		set WIXDEFINES=%WIXDEFINES% -dvs
 	) else (
+		echo Not including QML files
 		windeployqt -release jacktrip.exe
 	)
 	set WIXDEFINES=!WIXDEFINES! -ddynamic -dqt%QTVERSION%


### PR DESCRIPTION
ASIO requires a license from Steinberg (which JackTrip Labs has)

Don't include classic mode in signed JackTrip Labs builds for Mac and Windows

Clean up license docs to reflect latest updates