### PR TITLE
Work-around for broken base64 on macos 13

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -494,8 +494,8 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
           # import certificate and provisioning profile from secrets
-          echo -n "$APP_SIGNING_CERT_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "$INSTALLER_SIGNING_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
+          echo -n "$APP_SIGNING_CERT_BASE64" | base64 -d -o $CERTIFICATE_PATH
+          echo -n "$INSTALLER_SIGNING_CERT_BASE64" | base64 -d -o $INSTALLER_CERT_PATH
 
           # create temporary keychain
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
@@ -891,6 +891,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=edge,branch=dev
+            type=sha,branch=dev
             type=match,pattern=v(\d+.\d+)..*,group=1
             type=match,pattern=v(\d+.\d+.\d+).*,group=1,priority=950
             type=match,pattern=v(\d+.\d+.\d+-.*),group=1,priority=1000


### PR DESCRIPTION
Also add sha tag to container for develop branch builds

base64: invalid argument --output
Usage:	base64 [-hDd] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -Dd, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)