### PR TITLE
Try using runneradmin path recommended by ssl.com for CKA

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -766,8 +766,8 @@ jobs:
           CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
           SHA1: ${{ secrets.SSL_COM_SHA1 }}
           PASSWORD: ${{ secrets.SSL_COM_PWD }}
-          MASTER_KEY_FILE: ${{ github.workspace }}\CKA\master.key
-          INSTALL_DIR: ${{ github.workspace }}\CKA
+          MASTER_KEY_FILE: C:\Users\runneradmin\eSignerCKA\master.key
+          INSTALL_DIR: C:\Users\runneradmin\eSignerCKA
         run: |
           cd win
           echo Downloading Cloud Key Adapter...


### PR DESCRIPTION
Signing seems to have randomly stopped working, despite zero changes. Even re-running the same builds that worked before has started failing. Maybe it has something to do with using the workspace directory versus the path from ssl.com's example at https://www.ssl.com/how-to/how-to-integrate-esigner-cka-with-ci-cd-tools-for-automated-code-signing/